### PR TITLE
wrong param name inside README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const { Jitsi } = Plugins;
 const result = await Jitsi.joinConference({
    roomName: 'room1', // room identifier for the conference
    url: 'https://meet.jit.si' // endpoint of the Jitsi Meet video bridge,
-   token: string; // jwt authentication token
+   jwt: string; // jwt authentication token
    channelLastN: string; // last N participants allowed to join
    startWithAudioMuted: true, // start with audio muted
    startWithVideoMuted: false // start with video muted


### PR DESCRIPTION
(fix): The example in the README.md didn't work, there's a wrong param 'token' in Jitsi.joinConference, the correct name is 'jwt'.