### PR TITLE
Add the parameter p2pEnabled to can specify false in p2p option.

### DIFF
--- a/android/src/main/java/com/capacitor/jitsi/plugin/Jitsi.java
+++ b/android/src/main/java/com/capacitor/jitsi/plugin/Jitsi.java
@@ -43,6 +43,7 @@ public class Jitsi extends Plugin {
         Boolean recordingEnabled = call.getBoolean("recordingEnabled");
         Boolean liveStreamingEnabled = call.getBoolean("liveStreamingEnabled");
         Boolean screenSharingEnabled = call.getBoolean("screenSharingEnabled");
+        Boolean p2pEnabled = call.getBoolean("p2pEnabled");
 
         receiver = new JitsiBroadcastReceiver();
         receiver.setModule(this);
@@ -98,6 +99,9 @@ public class Jitsi extends Plugin {
         }
         if(screenSharingEnabled != null){
             intent.putExtra("screenSharingEnabled", screenSharingEnabled);
+        }
+        if(p2pEnabled != null){
+            intent.putExtra("p2pEnabled", p2pEnabled);
         }
 
         getActivity().startActivity(intent);

--- a/android/src/main/java/com/capacitor/jitsi/plugin/JitsiActivity.java
+++ b/android/src/main/java/com/capacitor/jitsi/plugin/JitsiActivity.java
@@ -64,6 +64,7 @@ public class JitsiActivity extends JitsiMeetActivity {
         Boolean recordingEnabled = getIntent().getBooleanExtra("recordingEnabled", false);
         Boolean liveStreamingEnabled = getIntent().getBooleanExtra("liveStreamingEnabled", true);
         Boolean screenSharingEnabled = getIntent().getBooleanExtra("screenSharingEnabled", false);
+        Boolean p2pEnabled = getIntent().getBooleanExtra("p2pEnabled", true);
 
         String displayName = getIntent().getStringExtra("displayName");
         String email = getIntent().getStringExtra("email");
@@ -99,6 +100,7 @@ public class JitsiActivity extends JitsiMeetActivity {
                 .setFeatureFlag("recording.enabled", recordingEnabled)
                 .setFeatureFlag("live-streaming.enabled", liveStreamingEnabled)
                 .setFeatureFlag("android.screensharing.enabled", screenSharingEnabled)
+                .setConfigOverride("p2p.enabled", p2pEnabled)
                 .setUserInfo(userInfo)
                 .build();
         view.join(options);

--- a/ios/Plugin/Plugin/JitsiMeetViewController.swift
+++ b/ios/Plugin/Plugin/JitsiMeetViewController.swift
@@ -23,6 +23,7 @@ public class JitsiMeetViewController: UIViewController {
     var screenSharingEnabled: Bool = false
     var recordingEnabled: Bool = false
     var liveStreamingEnabled: Bool? = nil
+    var p2pEnabled: Bool = true
     var email: String? = nil
     var displayName: String? = nil
     var avatarUrl: String? = nil
@@ -67,6 +68,7 @@ public class JitsiMeetViewController: UIViewController {
             builder.setFeatureFlag("call-integration.enabled", withBoolean: self.callIntegrationEnabled)
             builder.setFeatureFlag("ios.screensharing.enabled", withBoolean: self.screenSharingEnabled)
             builder.setFeatureFlag("ios.recording.enabled", withBoolean: self.recordingEnabled)
+            builder.setConfigOverride("p2p.enabled", withBoolean: self.p2pEnabled)
             if (self.liveStreamingEnabled != nil) {
                 builder.setFeatureFlag("live-streaming.enabled", withBoolean: self.liveStreamingEnabled ?? false)
             }

--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -41,6 +41,7 @@ public class Jitsi: CAPPlugin {
         self.jitsiMeetViewController.screenSharingEnabled = call.options["screenSharingEnabled"] as? Bool ?? false
         self.jitsiMeetViewController.recordingEnabled = call.options["recordingEnabled"] as? Bool ?? false
         self.jitsiMeetViewController.liveStreamingEnabled = call.options["liveStreamingEnabled"] as? Bool ?? nil
+        self.jitsiMeetViewController.p2pEnabled = call.options["p2pEnabled"] as? Bool ?? true
         self.jitsiMeetViewController.delegate = self;
 
         DispatchQueue.main.async {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -15,6 +15,7 @@ export interface JitsiPlugin {
         recordingEnabled?: boolean;
         liveStreamingEnabled?: boolean;
         screenSharingEnabled?: boolean;
+        p2pEnabled?: boolean;
     }): Promise<{
         roomName: string;
         url: string;
@@ -31,6 +32,7 @@ export interface JitsiPlugin {
         recordingEnabled?: boolean;
         liveStreamingEnabled?: boolean;
         screenSharingEnabled?: boolean;
+        p2pEnabled?: boolean;
     }>;
     leaveConference(options: {}): Promise<{}>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -20,6 +20,7 @@ export class JitsiWeb extends WebPlugin implements JitsiPlugin {
         recordingEnabled?: boolean;
         liveStreamingEnabled?: boolean;
         screenSharingEnabled?: boolean;
+        p2pEnabled?: boolean;
   }): Promise<{
         roomName: string;
         url: string;
@@ -36,6 +37,7 @@ export class JitsiWeb extends WebPlugin implements JitsiPlugin {
         recordingEnabled?: boolean;
         liveStreamingEnabled?: boolean;
         screenSharingEnabled?: boolean;
+        p2pEnabled?: boolean;
   }> {
       throw this.unavailable('the web implementation is not available. Please use Jitsi Meet API to implement Jitsi in web app');
   };


### PR DESCRIPTION
By default, the p2p option is true. This is causing in the case, a meeting of two participants (Browser to App) the video does not work well. I needed to specify the false value in the p2p option.
Thank you very much for this excellent plugin