### PR TITLE
Hotfix/dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/CapacitorJitsiMeet.podspec
+++ b/CapacitorJitsiMeet.podspec
@@ -15,5 +15,5 @@
     }
     s.ios.deployment_target  = '13.0'
     s.dependency 'Capacitor'
-    s.dependency 'JitsiMeetSDK', '8.6.2'
+    s.dependency 'JitsiMeetSDK', '8.6.1'
   end

--- a/CapacitorJitsiMeet.podspec
+++ b/CapacitorJitsiMeet.podspec
@@ -15,5 +15,5 @@
     }
     s.ios.deployment_target  = '13.0'
     s.dependency 'Capacitor'
-    s.dependency 'JitsiMeetSDK', '8.6.3'
+    s.dependency 'JitsiMeetSDK', '8.6.1'
   end

--- a/CapacitorJitsiMeet.podspec
+++ b/CapacitorJitsiMeet.podspec
@@ -15,5 +15,5 @@
     }
     s.ios.deployment_target  = '13.0'
     s.dependency 'Capacitor'
-    s.dependency 'JitsiMeetSDK', '8.6.1'
+    s.dependency 'JitsiMeetSDK', '8.6.3'
   end

--- a/CapacitorJitsiMeet.podspec
+++ b/CapacitorJitsiMeet.podspec
@@ -15,5 +15,5 @@
     }
     s.ios.deployment_target  = '13.0'
     s.dependency 'Capacitor'
-    s.dependency 'JitsiMeetSDK', '8.6.3'
+    s.dependency 'JitsiMeetSDK', '8.6.0'
   end

--- a/CapacitorJitsiMeet.podspec
+++ b/CapacitorJitsiMeet.podspec
@@ -15,5 +15,5 @@
     }
     s.ios.deployment_target  = '13.0'
     s.dependency 'Capacitor'
-    s.dependency 'JitsiMeetSDK', '8.6.0'
+    s.dependency 'JitsiMeetSDK', '8.6.2'
   end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation ('org.jitsi.react:jitsi-meet-sdk:8.6.0') { transitive = true }
+    implementation ('org.jitsi.react:jitsi-meet-sdk:8.6.3') { transitive = true }
 
     // Firebase
     implementation 'com.google.firebase:firebase-dynamic-links:16.1.5'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation ('org.jitsi.react:jitsi-meet-sdk:8.6.3') { transitive = true }
+    implementation ('org.jitsi.react:jitsi-meet-sdk:8.6.2') { transitive = true }
 
     // Firebase
     implementation 'com.google.firebase:firebase-dynamic-links:16.1.5'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation ('org.jitsi.react:jitsi-meet-sdk:8.6.2') { transitive = true }
+    implementation ('org.jitsi.react:jitsi-meet-sdk:8.6.1') { transitive = true }
 
     // Firebase
     implementation 'com.google.firebase:firebase-dynamic-links:16.1.5'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation ('org.jitsi.react:jitsi-meet-sdk:8.6.3') { transitive = true }
+    implementation ('org.jitsi.react:jitsi-meet-sdk:8.6.0') { transitive = true }
 
     // Firebase
     implementation 'com.google.firebase:firebase-dynamic-links:16.1.5'

--- a/ios/Plugin/Podfile
+++ b/ios/Plugin/Podfile
@@ -7,7 +7,7 @@ target 'Plugin' do
 
   # Pods for IonicRunner
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.2'
+  pod 'JitsiMeetSDK', '8.6.1'
 end
 
 post_install do |installer|
@@ -22,5 +22,5 @@ target 'PluginTests' do
   use_frameworks!
 
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.2'
+  pod 'JitsiMeetSDK', '8.6.1'
 end

--- a/ios/Plugin/Podfile
+++ b/ios/Plugin/Podfile
@@ -7,7 +7,7 @@ target 'Plugin' do
 
   # Pods for IonicRunner
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.3'
+  pod 'JitsiMeetSDK', '8.6.1'
 end
 
 post_install do |installer|
@@ -22,5 +22,5 @@ target 'PluginTests' do
   use_frameworks!
 
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.3'
+  pod 'JitsiMeetSDK', '8.6.1'
 end

--- a/ios/Plugin/Podfile
+++ b/ios/Plugin/Podfile
@@ -7,7 +7,7 @@ target 'Plugin' do
 
   # Pods for IonicRunner
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.0'
+  pod 'JitsiMeetSDK', '8.6.2'
 end
 
 post_install do |installer|
@@ -22,5 +22,5 @@ target 'PluginTests' do
   use_frameworks!
 
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.0'
+  pod 'JitsiMeetSDK', '8.6.2'
 end

--- a/ios/Plugin/Podfile
+++ b/ios/Plugin/Podfile
@@ -7,7 +7,7 @@ target 'Plugin' do
 
   # Pods for IonicRunner
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.3'
+  pod 'JitsiMeetSDK', '8.6.0'
 end
 
 post_install do |installer|
@@ -22,5 +22,5 @@ target 'PluginTests' do
   use_frameworks!
 
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.3'
+  pod 'JitsiMeetSDK', '8.6.0'
 end

--- a/ios/Plugin/Podfile
+++ b/ios/Plugin/Podfile
@@ -7,7 +7,7 @@ target 'Plugin' do
 
   # Pods for IonicRunner
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.1'
+  pod 'JitsiMeetSDK', '8.6.3'
 end
 
 post_install do |installer|
@@ -22,5 +22,5 @@ target 'PluginTests' do
   use_frameworks!
 
   pod 'Capacitor'
-  pod 'JitsiMeetSDK', '8.6.1'
+  pod 'JitsiMeetSDK', '8.6.3'
 end


### PR DESCRIPTION
8.6.3 didn't work where 8.6.1 worked for both iOS and Android. 

But it didn't solve the "Wait For Moderator" translation bug. Maybe we should contact the original maintainers of the jitsi-meet-sdk.